### PR TITLE
메인 페이지에 이미지가 나열 되도록 만들었습니다.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,11 @@ module.exports = {
   env: {
     es2021: true,
   },
+  globals: {
+    console: 'readonly',
+    document: 'readonly',
+    fetch: 'readonly',
+  },
   extends: ['airbnb-base', 'prettier'],
   parserOptions: {
     ecmaVersion: 12,

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Find Your Cat</title>
+    <link rel="stylesheet" href="../src/scss/app.scss" />
   </head>
 
   <body>


### PR DESCRIPTION
### Detail & Solution
---
메인 페이지에 100개의 이미지 전체가 로드 되도록 만들었습니다.

### What I did
---
어제 용재님의 설명을 바탕으로 console, fetch, document와 같이 eslint 상에서 에러 표시가 나는 것들을 global 설정을 통해 에러 표시가 없어지게 만들었습니다.

### To be supplemented
---
css 파일이 제대로 반영되지 않아 임시방편으로 인라인으로 작성해두었습니다. 추후에 분리가 필요합니다.
첫 메인 페이지에서 100개의 이미지를 전부 로드 시켰습니다. 하지만, 이는 비효율적입니다. 때문에 무한스크롤을 사용하여 이를 개선할 필요가 있겠습니다.