### PR TITLE
코드 리팩토링을 하였습니다.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,12 @@ module.exports = {
         endOfLine: 'auto',
       },
     ],
+    // webpack에서 alias 설정을 통해 절대경로로 바꿔주면 unresolve에러가 난다.(실제 에러가 나는 건 아니고 eslint의 에러) 이를 해결하기 위한 코드이다.
+    'import/no-unresolved': 'off',
+    // export const ~~~ 이런 식으로 쓰면 default를 쓰라고 eslint 에러가 나온다. 이를 해결하기 위한 코드
+    'import/prefer-default-export': 'off',
+    // await을 return하려면 eslint에러가 발생한다. 이를 해결하기 위한 코드
+    'no-return-await': 'off',
   },
   plugins: ['prettier'],
   settings: {

--- a/src/api/APIUtils.js
+++ b/src/api/APIUtils.js
@@ -1,0 +1,23 @@
+const API_ENDPOINT = 'https://api.thecatapi.com/v1';
+
+export default function myFetch({
+  url,
+  type = 'get',
+  param,
+  contentType = 'application/json',
+}) {
+  const URL = API_ENDPOINT + url;
+  const headers = {
+    'Content-Type': contentType,
+    // 'Access-Control-Allow-Origin': '*',
+    // 'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH',
+    // 'Access-Control-Allow-Headers':
+    // 'Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization',
+  };
+
+  return fetch(URL, {
+    method: type,
+    headers,
+    body: JSON.stringify(param),
+  });
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,1 @@
+export * from './theCatAPI';

--- a/src/api/theCatAPI.js
+++ b/src/api/theCatAPI.js
@@ -1,3 +1,7 @@
-const API_ENDPOINT = 'https://api.thecatapi.com/v1';
+import myFetch from './APIUtils';
 
-export default API_ENDPOINT;
+export const getRandomImageAPI = async () =>
+  await myFetch({
+    url: `/images/search?limit=100`,
+    type: 'get',
+  });

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
-import Header from './components/Header';
-import Searchbar from './components/Searchbar';
-import Cats from './components/Cats';
+import Header from '@components/Header';
+import Searchbar from '@components/Searchbar';
+import Cats from '@components/Cats';
 // import API_ENDPOINT from './api/theCatAPI';
 
 export default async function App() {

--- a/src/components/Cats.js
+++ b/src/components/Cats.js
@@ -1,21 +1,21 @@
 /* eslint-disable no-console */
-import API_ENDPOINT from '../api/theCatAPI';
+import { getRandomImageAPI } from '../api';
 
 export default async function Cats() {
   try {
-    const res = await fetch(`${API_ENDPOINT}/images/search?limit=100`);
+    const res = await getRandomImageAPI();
     const datas = res.json();
     let template = '';
     await datas.then((cat) => {
       cat.forEach((el) => {
         template += `
-          <div style="display:inline">
-            <img style="width:33%;height:300px;" src="${el.url}" />
+          <div class="max-small">
+            <img class="cat-image" src="${el.url}" />
           </div>`;
       });
     });
 
-    return `<div style="margin-top:20px;"${template}</div>`;
+    return `<div class="template" ${template}</div>`;
   } catch (error) {
     console.log(error);
   }

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 import App from './app';
 
+import './scss/index.scss';
+
 async function app() {
   document.getElementById('app').appendChild(await App());
 }

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -1,6 +1,12 @@
 .max-small {
-  width: auto;
-  height: auto;
-  max-width: 100px;
-  max-height: 100px;
+  display: inline;
+}
+
+.cat-image {
+  width: 33%;
+  height: 300px;
+}
+
+.template {
+  margin-top: 15px;
 }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -1,0 +1,2 @@
+@import url(./app.scss);
+@import url(./reset.css);

--- a/src/scss/reset.css
+++ b/src/scss/reset.css
@@ -1,0 +1,129 @@
+/* http://meyerweb.com/eric/tools/css/reset/
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: '';
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
     rules: [
       {
         // 처리할 모듈 형식 결정
-        test: /.js$/,
+        test: /\.js?$/,
         // 이 모듈에 사용할 loader
         use: 'babel-loader',
         // 제외할 파일들
@@ -64,6 +64,14 @@ module.exports = {
     publicPath: '/',
   },
 
+  resolve: {
+    extensions: ['.js'],
+    alias: {
+      '@components': path.resolve(__dirname, 'src/components'),
+      '@scss': path.resolve(__dirname, 'src/scss'),
+      '@api': path.resolve(__dirname, 'src/api'),
+    },
+  },
   // 번들링 된 파일이 생성될 위치 설정
   output: {
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
### Detail && Solution
---
@dididy 용재님의 코드를 바탕으로 전체적인 리팩토링을 하였습니다. 좋은 코드를 보여주셔서 진심으로 감사드립니다.
리팩토링의 핵심은 API 콜을 분리하는 일이었습니다. 실제 바닐라 자바스크립트 프로젝트 환경에서는 axios를 깔지 않고 해야 하는 경우가 생길 수 있기 때문에 이를 위한 코드를 작성해보았습니다.

### What I did
---
api 코드를 분리하였습니다. `88f1384`
css 파일을 분리하였습니다. `0fe79c4`
vue에서 가능한 정적인 디렉토리 접근을 위해 alias를 추가하였습니다. `0cd3650`
api 코드를 분리하다보니, eslint 에러들이 몇 개 발생하였고, 이를 수정했으며 어떤 부분이 어떤 에러를 막아주는지 명시하였습니다. `4fbeea1`

### What I need to do
---
- 무한스크롤을 구현하기 위해 observable pattern을 학습하고 있으나, 아직 사용할 수 있는 수준이 아닙니다. 사용할 수 있는 수준에 이르기 위한 학습이 필요합니다.
- sass에 대한 이해가 부족하다보니 사용하기가 어렵습니다. 조금 공부를 하고 사용해야 합니다.

## 오늘 했던 수정들은 용재님의 도움을 정말 많이 받았습니다. 다시 한 번 감사드립니다.